### PR TITLE
Hyphenated back-end

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 openmrs-module-htmlformflowsheet
 ================================
 
-Provides back end functionality to do a "patient chart"-style workflow (as opposed to form-based workflow)
+Provides back-end functionality to do a "patient chart"-style workflow (as opposed to form-based workflow)
 
 For full documentation, please visit:
 https://wiki.openmrs.org/display/docs/HtmlFormFlowsheet+Module


### PR DESCRIPTION
Should be hyphenated because it is a compound adjective.